### PR TITLE
Fix #14: support `super()` in wirerope

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ master, fix-super ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix-super ]
   pull_request:
     branches: [ master ]
 

--- a/wirerope/rope.py
+++ b/wirerope/rope.py
@@ -78,8 +78,8 @@ class PropertyRopeMixin(object):
             owner = obj if obj is not None else type
         if hasattr(self, 'wire_name'):
             wire_name = self.wire_name
-            # Lookup in `__dict__` instead of using `getattr`, because `getattr`
-            # falls back to class attributes.
+            # Lookup in `__dict__` instead of using `getattr`, because
+            # `getattr` falls back to class attributes.
             wire = owner.__dict__.get(wire_name)
         else:
             wire_name_parts = ['__wire_', cw.wrapped_callable.__name__]


### PR DESCRIPTION
This PR fixes issue #14: it adds support for calling `super()` for `WireRope`-decorated descriptors.

This is done by defining `__set_name__` on the descriptor mixins. During class construction, for each descriptor defined in the class, its `__set_name__` method (if exists) will be invoked with the class object and attribute name. This makes the descriptor aware of the class it's defined in, and the name it's associated with, which then allows us to differentiate between descriptors defined in a super class vs. those defined in the current class.

Due to implementation limits, this is only supported for Python 3.6+; other versions will use the old behavior.

For more information, see the [Python docs](https://docs.python.org/3/reference/datamodel.html#class-object-creation) or [PEP 487](https://www.python.org/dev/peps/pep-0487/#implementation-details).