### PR TITLE
Fix setuptools version parsing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 - '3.4'
 - nightly
 install:
-- pip install --upgrade pip setuptools
+- pip install --upgrade pip
 - pip install flake8 pytest-cov .
 - pip install -e '.[test]'
 script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
 import setuptools
 
-assert tuple(map(int, setuptools.__version__.split('.')[:3])) >= (39, 2, 0), \
-    'Plesase upgrade setuptools by `pip install -U setuptools`'
-
 setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,13 @@
 import setuptools
+from pkg_resources import get_distribution
+
+try:
+    get_distribution("setuptools>=39.2.0")
+except Exception as e:
+    raise AssertionError(
+        "Please upgrade setuptools by `pip install -U setuptools`: {}".format(
+            e
+        )
+    )
 
 setuptools.setup()


### PR DESCRIPTION
This eliminates the need to do it by modernizing and ensuring a minimum
setuptools via PEP-517 / PEP-518, but the check is kept and made robust
for those who might still want to run `python setup.py` (instead of 
`pip install .` which will use the `pyproject.toml` and ensure the 
setuptools build dependency is up to date).

Fixes #8